### PR TITLE
Add the ability to get the UUIDs from the Android framework BluetoothDevice object

### DIFF
--- a/android/src/main/kotlin/dev/lenhart/flutter_blue_classic/BlueClassicHelper.kt
+++ b/android/src/main/kotlin/dev/lenhart/flutter_blue_classic/BlueClassicHelper.kt
@@ -61,6 +61,7 @@ class BlueClassicHelper {
             entry["bondState"] = bondStateString(device.bondState)
             entry["deviceType"] = deviceTypeString(device.type)
             entry["rssi"] = rssi
+            entry["uuids"] = device.uuids?.map { it.toString() } ?: emptyList<String>()
             return entry
         }
     }

--- a/lib/src/model/bluetooth_device.dart
+++ b/lib/src/model/bluetooth_device.dart
@@ -21,13 +21,17 @@ class BluetoothDevice {
   /// Bonding state of the device.
   final BluetoothBondState bondState;
 
+  /// The UUIDs supported by the device.
+  final List<String> uuids;
+
   BluetoothDevice._(
       {required this.address,
       this.name = "",
       this.alias,
       this.type = BluetoothDeviceType.unknown,
       this.rssi,
-      this.bondState = BluetoothBondState.none});
+      this.bondState = BluetoothBondState.none,
+      this.uuids = const []});
   factory BluetoothDevice.fromMap(Map map) => BluetoothDevice._(
       name: map["name"],
       alias: map["alias"],
@@ -38,7 +42,8 @@ class BluetoothDevice {
       rssi: map["rssi"],
       bondState: BluetoothBondState.values.firstWhere(
           (e) => e.name == map["bondState"],
-          orElse: () => BluetoothBondState.none));
+          orElse: () => BluetoothBondState.none),
+      uuids: List<String>.from(map["uuids"] ?? []));
 
   @override
   operator ==(Object other) {


### PR DESCRIPTION
Inspecting the list of UUIDs is useful when probing bonded devices, as an application that uses a custom UUID for RFCOMM connections can find compatible devices.

Note that such the remote device would have to expose the custom UUID during SDP.